### PR TITLE
Make stderr redirection compatible with Fish 3.0.

### DIFF
--- a/tiny.fish
+++ b/tiny.fish
@@ -119,7 +119,7 @@ function tiny -d "get a git.io short URL"
       import plugins/pbcopy
     end
     # Print to stdout, copy to stderr pipe it into pbcopy.
-    echo "$url" | tee /dev/stderr ^| pbcopy ^/dev/null
+    echo "$url" | tee /dev/stderr 2>| pbcopy 2> /dev/null
 
     set -q open
       and open "$url"


### PR DESCRIPTION
Fish has deprecated `^` as a shortcut for stderr redirection in 3.0. Replace it with the more
compatible `2>`.

See oh-my-fish/oh-my-fish#609 and oh-my-fish/oh-my-fish#618